### PR TITLE
fix: harden mpv/GL lifecycle and surface playback errors

### DIFF
--- a/src/app/imp.rs
+++ b/src/app/imp.rs
@@ -1,0 +1,251 @@
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
+
+use adw::{prelude::*, subclass::prelude::*};
+use gtk::glib::{self, Properties, clone};
+
+use crate::app::{
+    config::{PRELOAD_SCRIPT, URI_SCHEME, URL_DEV, URL_PROD},
+    ipc::{
+        self,
+        event::{IpcEvent, IpcEventMpv},
+    },
+    tray::Tray,
+    video::Video,
+    webview::WebView,
+    window::Window,
+};
+
+#[derive(Properties, Default)]
+#[properties(wrapper_type = super::Application)]
+pub struct Application {
+    #[property(get, set)]
+    dev_mode: Cell<bool>,
+    tray: RefCell<Option<Tray>>,
+    video: RefCell<Option<Video>>,
+    webview: RefCell<Option<WebView>>,
+    deeplink: Rc<RefCell<Option<String>>>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for Application {
+    const NAME: &'static str = "Application";
+    type Type = super::Application;
+    type ParentType = adw::Application;
+}
+
+#[glib::derived_properties]
+impl ObjectImpl for Application {}
+
+impl ApplicationImpl for Application {
+    fn startup(&self) {
+        self.parent_startup();
+
+        let app = self.obj();
+        app.setup_actions();
+        app.setup_accels();
+    }
+
+    fn activate(&self) {
+        self.parent_activate();
+
+        let app = self.obj();
+
+        if let Some(window) = app.active_window() {
+            window.present();
+            return;
+        }
+
+        let tray = Tray::default();
+        let video = Video::default();
+
+        let dev_mode = self.dev_mode.get();
+
+        let url = match dev_mode {
+            true => URL_DEV,
+            false => URL_PROD,
+        };
+
+        let webview = WebView::default();
+        webview.load_uri(url);
+        webview.inject_script(PRELOAD_SCRIPT);
+        webview.dev_mode(dev_mode);
+
+        let window = Window::new(&app);
+        window.set_underlay(&video);
+        window.set_overlay(&webview);
+
+        video.connect_playback_started(clone!(
+            #[weak]
+            window,
+            move || {
+                window.disable_idling();
+            }
+        ));
+
+        video.connect_playback_ended(clone!(
+            #[weak]
+            window,
+            move || {
+                window.enable_idling();
+            }
+        ));
+
+        video.connect_property_change(clone!(
+            #[weak]
+            webview,
+            move |name, value| {
+                let message = ipc::create_response(IpcEvent::Mpv(IpcEventMpv::Change((
+                    name.to_string(),
+                    value,
+                ))));
+
+                webview.send(&message);
+            }
+        ));
+
+        video.connect_mpv_ended(clone!(
+            #[weak]
+            webview,
+            move |error| {
+                let message = ipc::create_response(IpcEvent::Mpv(IpcEventMpv::Ended(error)));
+                webview.send(&message);
+            }
+        ));
+
+        video.connect_mpv_error(clone!(
+            #[weak]
+            webview,
+            move |error| {
+                let message = ipc::create_response(IpcEvent::Mpv(IpcEventMpv::Ended(Some(error))));
+                webview.send(&message);
+            }
+        ));
+
+        let deeplink = self.deeplink.clone();
+        webview.connect_ipc(clone!(
+            #[weak]
+            app,
+            #[weak]
+            window,
+            #[weak]
+            video,
+            move |webview: WebView, message: &str| {
+                if let Ok(event) = ipc::parse_request(message) {
+                    match event {
+                        IpcEvent::Init => {
+                            let message = ipc::create_response(IpcEvent::Init);
+                            webview.send(&message);
+                        }
+                        IpcEvent::Ready => {
+                            if let Some(ref uri) = *deeplink.borrow() {
+                                let message =
+                                    ipc::create_response(IpcEvent::OpenMedia(uri.to_string()));
+                                webview.send(&message);
+                            }
+                        }
+                        IpcEvent::Fullscreen(state) => {
+                            window.set_fullscreen(state);
+
+                            let message = ipc::create_response(IpcEvent::Fullscreen(state));
+                            webview.send(&message);
+                        }
+                        IpcEvent::Quit => {
+                            app.quit();
+                        }
+                        IpcEvent::Mpv(event) => match event {
+                            IpcEventMpv::Observe(name) => video.observe_property(name),
+                            IpcEventMpv::Command((name, args)) => video.send_command(name, args),
+                            IpcEventMpv::Set((name, value)) => video.set_property(name, value),
+                            _ => {}
+                        },
+                        _ => {}
+                    }
+                }
+            }
+        ));
+
+        webview.connect_fullscreen(clone!(
+            #[weak]
+            window,
+            move |fullscreen: bool| {
+                window.set_fullscreen(fullscreen);
+            }
+        ));
+
+        webview.connect_open_external(clone!(
+            #[weak]
+            window,
+            move |uri| {
+                window.open_uri(uri.to_string());
+            }
+        ));
+
+        window.connect_visibility(clone!(
+            #[weak]
+            webview,
+            #[weak]
+            tray,
+            move |state| {
+                let message = ipc::create_response(IpcEvent::Visibility(state));
+                webview.send(&message);
+
+                tray.update(state);
+            }
+        ));
+
+        tray.connect_show(clone!(
+            #[weak]
+            window,
+            move || {
+                window.set_visible(true);
+            }
+        ));
+
+        tray.connect_hide(clone!(
+            #[weak]
+            window,
+            move || {
+                window.set_visible(false);
+            }
+        ));
+
+        tray.connect_quit(clone!(
+            #[weak]
+            app,
+            move || {
+                app.quit();
+            }
+        ));
+
+        *self.tray.borrow_mut() = Some(tray);
+        *self.video.borrow_mut() = Some(video);
+        *self.webview.borrow_mut() = Some(webview);
+
+        window.present();
+    }
+
+    fn open(&self, files: &[gtk::gio::File], hint: &str) {
+        self.parent_open(files, hint);
+
+        self.activate();
+
+        if let Some(file) = files.first() {
+            let uri = file.uri().to_string();
+            if uri.starts_with(URI_SCHEME) {
+                let mut deeplink = self.deeplink.borrow_mut();
+                *deeplink = Some(uri.clone());
+
+                if let Some(ref webview) = *self.webview.borrow() {
+                    let message = ipc::create_response(IpcEvent::OpenMedia(uri));
+                    webview.send(&message);
+                }
+            }
+        }
+    }
+}
+
+impl GtkApplicationImpl for Application {}
+impl AdwApplicationImpl for Application {}

--- a/src/app/video/imp.rs
+++ b/src/app/video/imp.rs
@@ -1,0 +1,311 @@
+use gtk::{
+    gdk::GLContext,
+    glib::{self, Propagation, Variant, subclass::Signal},
+    prelude::*,
+    subclass::prelude::*,
+};
+use libc::{LC_NUMERIC, setlocale};
+use libmpv2::{
+    Format, Mpv, SetData,
+    events::{Event, PropertyData},
+    render::{OpenGLInitParams, RenderContext, RenderParam, RenderParamApiType},
+};
+use std::{
+    cell::{Cell, RefCell},
+    env,
+    os::raw::c_void,
+    sync::{
+        OnceLock,
+        mpsc::{TryRecvError, channel},
+    },
+};
+use tracing::error;
+
+fn get_proc_address(_context: &GLContext, name: &str) -> *mut c_void {
+    epoxy::get_proc_addr(name) as _
+}
+
+pub struct Video {
+    mpv: RefCell<Mpv>,
+    render_context: RefCell<Option<RenderContext>>,
+    fbo: Cell<u32>,
+    mapped: Cell<bool>,
+}
+
+impl Default for Video {
+    fn default() -> Self {
+        // Required for libmpv to work alongside gtk
+        unsafe {
+            setlocale(LC_NUMERIC, c"C".as_ptr());
+        }
+
+        let log = env::var("RUST_LOG");
+        let msg_level = match log {
+            Ok(scope) => &format!("all={}", scope.as_str()),
+            _ => "all=no",
+        };
+
+        let mpv = Mpv::with_initializer(|init| {
+            init.set_property("vo", "libmpv")?;
+            init.set_property("video-timing-offset", "0")?;
+            init.set_property("terminal", "yes")?;
+            init.set_property("msg-level", msg_level)?;
+            Ok(())
+        })
+        .expect("Failed to create mpv");
+
+        mpv.disable_deprecated_events().ok();
+
+        // Ensure hwdec failures fall back to software decode instead of aborting playback.
+        if mpv.set_property("hwdec", "auto-safe").is_err() {
+            mpv.set_property("hwdec", "no").ok();
+        }
+        mpv.set_property("vd-lavc-dr", "yes").ok();
+        mpv.set_property("opengl-pbo", "yes").ok();
+
+        Self {
+            mpv: RefCell::new(mpv),
+            render_context: Default::default(),
+            fbo: Default::default(),
+            mapped: Cell::new(false),
+        }
+    }
+}
+
+impl Video {
+    fn fbo(&self) -> i32 {
+        let mut fbo = self.fbo.get();
+
+        if fbo == 0 {
+            let mut current_fbo = 0i32;
+
+            unsafe {
+                epoxy::GetIntegerv(epoxy::FRAMEBUFFER_BINDING, &mut current_fbo);
+            }
+
+            fbo = current_fbo as u32;
+            self.fbo.set(fbo);
+        }
+
+        fbo as i32
+    }
+
+    fn on_event<T: Fn(Event)>(&self, callback: T) {
+        // Drain the queue non-blocking to avoid backlogs during bursts.
+        for _ in 0..32 {
+            if let Some(result) = self.mpv.borrow_mut().wait_event(0.0) {
+                match result {
+                    Ok(event) => callback(event),
+                    Err(e) => {
+                        error!("Failed to wait for event: {e}");
+                        break;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    pub fn send_command(&self, name: &str, args: &[&str]) {
+        if let Err(e) = self.mpv.borrow().command(name, args) {
+            error!("Failed to send command {name}: {e}");
+        }
+    }
+
+    pub fn observe_property(&self, name: &str, format: Format) {
+        if let Err(e) = self.mpv.borrow().observe_property(name, format, 0) {
+            error!("Failed to observe property {name}: {e}");
+        }
+    }
+
+    pub fn set_property<T: SetData>(&self, name: &str, value: T) {
+        if let Err(e) = self.mpv.borrow().set_property(name, value) {
+            error!("Failed to set property {name}: {e}");
+        }
+    }
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for Video {
+    const NAME: &'static str = "Video";
+    type Type = super::Video;
+    type ParentType = gtk::GLArea;
+}
+
+impl ObjectImpl for Video {
+    fn signals() -> &'static [Signal] {
+        static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+        SIGNALS.get_or_init(|| {
+            vec![
+                Signal::builder("property-changed")
+                    .param_types([str::static_type(), Variant::static_type()])
+                    .build(),
+                Signal::builder("playback-started").build(),
+                Signal::builder("playback-ended").build(),
+                Signal::builder("mpv-ended")
+                    .param_types([Option::<String>::static_type()])
+                    .build(),
+                Signal::builder("mpv-error")
+                    .param_types([String::static_type()])
+                    .build(),
+            ]
+        })
+    }
+
+    fn constructed(&self) {
+        self.parent_constructed();
+
+        let video_weak = self.downgrade();
+        let object_weak = self.obj().downgrade();
+
+        glib::idle_add_local(move || {
+            if let Some(video) = video_weak.upgrade()
+                && let Some(object) = object_weak.upgrade()
+            {
+                video.on_event(|event| match event {
+                    Event::PropertyChange { name, change, .. } => {
+                        let value = match change {
+                            PropertyData::Str(v) => Some(v.to_variant()),
+                            PropertyData::Flag(v) => Some(v.to_variant()),
+                            PropertyData::Double(v) => Some(v.to_variant()),
+                            _ => None,
+                        };
+
+                        if let Some(value) = value {
+                            object.emit_by_name::<()>("property-changed", &[&name, &value]);
+                        }
+                    }
+                    Event::StartFile => {
+                        object.emit_by_name::<()>("playback-started", &[]);
+                    }
+                    Event::EndFile(reason) => {
+                        object.emit_by_name::<()>("playback-ended", &[]);
+
+                        let error = match reason {
+                            4 => Some("error".to_string()),
+                            5 => Some("redirect".to_string()),
+                            // Match any other non-success code as unknown, including potential future values.
+                            r if r > 3 => Some("unknown".to_string()),
+                            _ => None,
+                        };
+
+                        object.emit_by_name::<()>("mpv-ended", &[&error]);
+                    }
+                    _ => {}
+                });
+
+                return glib::ControlFlow::Continue;
+            }
+
+            glib::ControlFlow::Break
+        });
+    }
+}
+
+impl WidgetImpl for Video {
+    fn map(&self) {
+        self.mapped.set(true);
+        self.parent_map();
+    }
+
+    fn unmap(&self) {
+        self.mapped.set(false);
+        self.parent_unmap();
+    }
+
+    fn realize(&self) {
+        self.parent_realize();
+
+        // Ensure we start with a clean framebuffer reference for this GL context.
+        self.fbo.set(0);
+
+        let object = self.obj();
+        object.make_current();
+
+        if object.error().is_some() {
+            return;
+        }
+
+        if let Some(context) = object.context() {
+            let mut mpv = self.mpv.borrow_mut();
+            let mpv_handle = unsafe { mpv.ctx.as_mut() };
+
+            let mut render_context = match RenderContext::new(
+                mpv_handle,
+                vec![
+                    RenderParam::ApiType(RenderParamApiType::OpenGl),
+                    RenderParam::InitParams(OpenGLInitParams {
+                        get_proc_address,
+                        ctx: context,
+                    }),
+                    RenderParam::BlockForTargetTime(false),
+                ],
+            ) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    error!("Failed to create render context: {e}");
+                    return;
+                }
+            };
+
+            let (sender, receiver) = channel::<()>();
+
+            let object_weak = object.downgrade();
+            glib::idle_add_local(move || match receiver.try_recv() {
+                Ok(()) => {
+                    if let Some(object) = object_weak.upgrade() {
+                        if object.is_visible() && object.is_mapped() {
+                            object.queue_render();
+                        }
+                        glib::ControlFlow::Continue
+                    } else {
+                        glib::ControlFlow::Break
+                    }
+                }
+                Err(TryRecvError::Empty) => glib::ControlFlow::Continue,
+                Err(TryRecvError::Disconnected) => glib::ControlFlow::Break,
+            });
+
+            render_context.set_update_callback(move || {
+                let _ = sender.send(());
+            });
+
+            *self.render_context.borrow_mut() = Some(render_context);
+        }
+    }
+
+    fn unrealize(&self) {
+        if let Some(render_context) = self.render_context.borrow_mut().take() {
+            drop(render_context);
+        }
+
+        // Drop cached FBO so a new GL context gets a fresh binding.
+        self.fbo.set(0);
+
+        self.parent_unrealize();
+    }
+}
+
+impl GLAreaImpl for Video {
+    fn render(&self, _context: &GLContext) -> Propagation {
+        let object = self.obj();
+
+        let fbo = self.fbo();
+        let width = object.width();
+        let height = object.height();
+
+        if width == 0 || height == 0 || !object.is_mapped() || !object.is_visible() {
+            return Propagation::Stop;
+        }
+
+        if let Some(ref render_context) = *self.render_context.borrow() {
+            if let Err(e) = render_context.render::<GLContext>(fbo, width, height, true) {
+                error!("Failed to render frame: {e}");
+                object.emit_by_name::<()>("mpv-error", &[&e.to_string()]);
+            }
+        }
+
+        Propagation::Stop
+    }
+}

--- a/src/app/video/mod.rs
+++ b/src/app/video/mod.rs
@@ -1,0 +1,146 @@
+mod config;
+mod imp;
+
+use adw::subclass::prelude::ObjectSubclassIsExt;
+use gtk::glib::{self, Variant, closure_local, object::ObjectExt};
+use itertools::Itertools;
+use libmpv2::Format;
+use serde_json::{Number, Value};
+use tracing::error;
+
+use crate::app::video::config::{BOOL_PROPERTIES, FLOAT_PROPERTIES, STRING_PROPERTIES};
+
+glib::wrapper! {
+    pub struct Video(ObjectSubclass<imp::Video>)
+        @extends gtk::GLArea, gtk::Widget,
+        @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
+}
+
+impl Default for Video {
+    fn default() -> Self {
+        glib::Object::builder()
+            .property("hexpand", true)
+            .property("vexpand", true)
+            .build()
+    }
+}
+
+impl Video {
+    pub fn connect_property_change<T: Fn(&str, Value) + 'static>(&self, callback: T) {
+        self.connect_closure(
+            "property-changed",
+            false,
+            closure_local!(move |_: Video, name: &str, value: Variant| {
+                match name {
+                    name if FLOAT_PROPERTIES.contains(&name) => {
+                        if let Some(value) = value.get::<f64>() {
+                            callback(name, Value::Number(Number::from_f64(value).unwrap()))
+                        }
+                    }
+                    name if BOOL_PROPERTIES.contains(&name) => {
+                        if let Some(value) = value.get::<bool>() {
+                            callback(name, Value::Bool(value))
+                        }
+                    }
+                    name if STRING_PROPERTIES.contains(&name) => {
+                        if let Some(value) = value.get::<String>() {
+                            if let Ok(json_value) = serde_json::from_str::<Value>(&value) {
+                                callback(name, json_value)
+                            } else {
+                                callback(name, Value::String(value))
+                            }
+                        }
+                    }
+                    _ => {}
+                };
+            }),
+        );
+    }
+
+    pub fn connect_playback_started<T: Fn() + 'static>(&self, callback: T) {
+        self.connect_closure(
+            "playback-started",
+            false,
+            closure_local!(move |_: Video| {
+                callback();
+            }),
+        );
+    }
+
+    pub fn connect_playback_ended<T: Fn() + 'static>(&self, callback: T) {
+        self.connect_closure(
+            "playback-ended",
+            false,
+            closure_local!(move |_: Video| {
+                callback();
+            }),
+        );
+    }
+
+    pub fn connect_mpv_ended<T: Fn(Option<String>) + 'static>(&self, callback: T) {
+        self.connect_closure(
+            "mpv-ended",
+            false,
+            closure_local!(move |_: Video, error: Option<String>| {
+                callback(error);
+            }),
+        );
+    }
+
+    pub fn connect_mpv_error<T: Fn(String) + 'static>(&self, callback: T) {
+        self.connect_closure(
+            "mpv-error",
+            false,
+            closure_local!(move |_: Video, error: String| {
+                callback(error);
+            }),
+        );
+    }
+
+    pub fn send_command(&self, name: String, args: Vec<String>) {
+        let widget = self.imp();
+
+        let args = args.iter().map(String::as_ref).collect_vec();
+        widget.send_command(&name, &args);
+    }
+
+    pub fn observe_property(&self, name: String) {
+        let widget = self.imp();
+
+        match name.as_str() {
+            name if FLOAT_PROPERTIES.contains(&name) => {
+                widget.observe_property(name, Format::Double);
+            }
+            name if BOOL_PROPERTIES.contains(&name) => {
+                widget.observe_property(name, Format::Flag);
+            }
+            name if STRING_PROPERTIES.contains(&name) => {
+                widget.observe_property(name, Format::String);
+            }
+            _ => error!("Failed to observe property {name}: Unsupported"),
+        };
+    }
+
+    pub fn set_property(&self, name: String, value: Value) {
+        let widget = self.imp();
+
+        match name.as_str() {
+            name if FLOAT_PROPERTIES.contains(&name) => {
+                if let Some(value) = value.as_f64() {
+                    widget.set_property(name, value);
+                }
+            }
+            name if BOOL_PROPERTIES.contains(&name) => {
+                if let Some(value) = value.as_bool() {
+                    widget.set_property(name, value);
+                }
+            }
+            name if STRING_PROPERTIES.contains(&name) => {
+                if let Some(value) = value.as_str() {
+                    widget.set_property(name, value);
+                }
+            }
+            name => error!("Failed to set property {name}: Unsupported"),
+        };
+    }
+}


### PR DESCRIPTION
- Guard GL rendering against zero-size/hidden/unmapped surfaces, reset FBO on context changes, and avoid panics on render/init errors.
- Request hwdec with safe fallback, keep mpv event drain bounded, and stop using stale GL resources when the widget unmaps/unrealizes.
- Surface mpv end/error events to the webview via IPC (new signals) so the UI can react gracefully to playback failures.