### PR TITLE
refactor/gtk4: fix scaling issues

### DIFF
--- a/src/app/imp.rs
+++ b/src/app/imp.rs
@@ -227,9 +227,9 @@ impl ApplicationImpl for Application {
         });
 
         let browser = self.browser.clone();
-        webview.connect_resized(move |width, height| {
+        webview.connect_resized(move |width, height, scale| {
             if let Some(ref browser) = *browser.borrow() {
-                browser.resize(width, height);
+                browser.resize(width, height, scale);
             }
         });
 

--- a/src/app/imp.rs
+++ b/src/app/imp.rs
@@ -83,13 +83,10 @@ impl ApplicationImpl for Application {
         window.connect_monitor_info(clone!(
             #[weak]
             video,
-            #[weak]
-            webview,
-            move |refresh_rate, scale_factor| {
+            move |refresh_rate, scale_factor: f64| {
                 if let Some(ref browser) = *browser.borrow() {
                     browser.set_monitor_info(refresh_rate, scale_factor);
-                    video.set_property("scale-factor", scale_factor);
-                    webview.set_property("scale-factor", scale_factor);
+                    video.set_property("scale-factor", scale_factor.ceil() as i32);
                 }
             }
         ));

--- a/src/app/imp.rs
+++ b/src/app/imp.rs
@@ -83,11 +83,15 @@ impl ApplicationImpl for Application {
         window.connect_monitor_info(clone!(
             #[weak]
             video,
+            #[weak]
+            webview,
             move |refresh_rate, scale_factor: f64| {
                 if let Some(ref browser) = *browser.borrow() {
                     browser.set_monitor_info(refresh_rate, scale_factor);
                     video.set_property("scale-factor", scale_factor.ceil() as i32);
                 }
+                // Trigger size_allocate to recompute device pixel dimensions
+                webview.queue_allocate();
             }
         ));
 

--- a/src/app/webview/imp.rs
+++ b/src/app/webview/imp.rs
@@ -1,50 +1,41 @@
-use std::{cell::Cell, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use adw::subclass::prelude::*;
 use crossbeam_queue::SegQueue;
-use epoxy::types::{GLint, GLuint};
 use gtk::{
     DropTarget,
-    gdk::{DragAction, FileList, GLContext},
-    glib::{self, ControlFlow, Propagation, Properties},
+    gdk::{DragAction, FileList, MemoryFormat, MemoryTexture},
+    glib::{self, Bytes, ControlFlow, Properties},
+    graphene,
     prelude::*,
 };
 
-use crate::{
-    app::webview::gl,
-    shared::{
-        Frame,
-        states::{KeyboardState, PointerState},
-    },
+use crate::shared::{
+    Frame,
+    states::{KeyboardState, PointerState},
 };
 
-pub const FRAGMENT_SRC: &str = include_str!("shader.frag");
-pub const VERTEX_SRC: &str = include_str!("shader.vert");
-pub const UPDATES_PER_RENDER: i32 = 8;
+const BYTES_PER_PIXEL: usize = 4;
 
 #[derive(Default, Properties)]
 #[properties(wrapper_type = super::WebView)]
 pub struct WebView {
     #[property(get, set)]
-    scale_factor: Cell<i32>,
-    program: Cell<GLuint>,
-    vao: Cell<GLuint>,
-    vbo: Cell<GLuint>,
-    pbo: Cell<GLuint>,
-    texture: Cell<GLuint>,
-    texture_uniform: Cell<GLint>,
-    texture_height: Cell<i32>,
-    texture_width: Cell<i32>,
+    dummy: std::cell::Cell<i32>,
+    frame_buffer: RefCell<Vec<u8>>,
+    frame_width: std::cell::Cell<i32>,
+    frame_height: std::cell::Cell<i32>,
     pub pointer_state: Rc<PointerState>,
     pub keyboard_state: Rc<KeyboardState>,
     pub frames: Box<SegQueue<Frame>>,
+    pub resize_callback: RefCell<Option<Box<dyn Fn(i32, i32)>>>,
 }
 
 #[glib::object_subclass]
 impl ObjectSubclass for WebView {
     const NAME: &'static str = "WebView";
     type Type = super::WebView;
-    type ParentType = gtk::GLArea;
+    type ParentType = gtk::Widget;
 }
 
 #[glib::derived_properties]
@@ -54,108 +45,97 @@ impl ObjectImpl for WebView {
 
         let drop_target = DropTarget::new(FileList::static_type(), DragAction::COPY);
         self.obj().add_controller(drop_target);
-    }
-}
-
-impl WidgetImpl for WebView {
-    fn realize(&self) {
-        self.parent_realize();
-
-        let gl_area = self.obj();
-        gl_area.make_current();
-
-        if gl_area.error().is_some() {
-            return;
-        }
-
-        let vertex_shader = gl::compile_vertex_shader(VERTEX_SRC);
-        let fragment_shader = gl::compile_fragment_shader(FRAGMENT_SRC);
-        let program = gl::create_program(vertex_shader, fragment_shader);
-        let (vao, vbo) = gl::create_geometry(program);
-        let pbo = gl::create_pbo();
-        let (texture, texture_uniform) = gl::create_texture(program, "text_uniform");
-
-        self.program.set(program);
-        self.vao.set(vao);
-        self.vbo.set(vbo);
-        self.pbo.set(pbo);
-        self.texture.set(texture);
-        self.texture_uniform.set(texture_uniform);
 
         self.obj().add_tick_callback(|webview, _| {
             if !webview.imp().frames.is_empty() {
-                webview.queue_render();
+                webview.queue_draw();
             }
 
             ControlFlow::Continue
         });
     }
-
-    fn unrealize(&self) {
-        unsafe {
-            epoxy::DeleteProgram(self.program.get());
-            epoxy::DeleteTextures(1, &self.texture.get());
-            epoxy::DeleteBuffers(1, &self.vbo.get());
-            epoxy::DeleteVertexArrays(1, &self.vao.get());
-            epoxy::DeleteBuffers(1, &self.pbo.get());
-        }
-
-        self.program.take();
-        self.vao.take();
-        self.vbo.take();
-        self.texture.take();
-        self.texture_uniform.take();
-
-        self.parent_unrealize();
-    }
 }
 
-impl GLAreaImpl for WebView {
-    fn render(&self, _: &GLContext) -> Propagation {
-        let scale_factor = self.scale_factor.get();
-        let mut redraw = false;
+impl WidgetImpl for WebView {
+    fn snapshot(&self, snapshot: &gtk::Snapshot) {
+        // Apply pending frames to the CPU buffer
+        let mut buffer = self.frame_buffer.borrow_mut();
 
-        for _ in 0..UPDATES_PER_RENDER {
-            if let Some(frame) = self.frames.pop() {
-                let width = self.texture_width.get();
-                let height = self.texture_height.get();
+        while let Some(frame) = self.frames.pop() {
+            let width = self.frame_width.get();
+            let height = self.frame_height.get();
 
-                if frame.full_width != width || frame.full_height != height {
-                    gl::resize_texture(self.texture.get(), frame.full_width, frame.full_height);
-                    self.texture_width.set(frame.full_width);
-                    self.texture_height.set(frame.full_height);
+            // If full dimensions changed, resize buffer
+            if frame.full_width != width || frame.full_height != height {
+                let new_size =
+                    (frame.full_width as usize) * (frame.full_height as usize) * BYTES_PER_PIXEL;
+                buffer.resize(new_size, 0);
+                self.frame_width.set(frame.full_width);
+                self.frame_height.set(frame.full_height);
+            }
+
+            let buf_width = self.frame_width.get() as usize;
+
+            // Blit dirty rect into full buffer
+            let src_stride = frame.width as usize * BYTES_PER_PIXEL;
+            let dst_stride = buf_width * BYTES_PER_PIXEL;
+
+            for row in 0..frame.height as usize {
+                let src_offset = row * src_stride;
+                let dst_offset =
+                    (frame.y as usize + row) * dst_stride + frame.x as usize * BYTES_PER_PIXEL;
+
+                if src_offset + src_stride <= frame.buffer.len()
+                    && dst_offset + src_stride <= buffer.len()
+                {
+                    buffer[dst_offset..dst_offset + src_stride]
+                        .copy_from_slice(&frame.buffer[src_offset..src_offset + src_stride]);
                 }
-
-                gl::update_texture(
-                    self.pbo.get(),
-                    self.texture.get(),
-                    frame.x,
-                    frame.y,
-                    frame.width,
-                    frame.height,
-                    &frame.buffer,
-                );
-
-                redraw = true;
-            } else {
-                break;
             }
         }
 
-        if redraw {
-            let width = self.texture_width.get();
-            let height = self.texture_height.get();
+        let width = self.frame_width.get();
+        let height = self.frame_height.get();
+        let expected_size = (width as usize) * (height as usize) * BYTES_PER_PIXEL;
 
-            gl::resize_viewport(width * scale_factor, height * scale_factor);
-
-            gl::draw_texture(
-                self.program.get(),
-                self.texture.get(),
-                self.texture_uniform.get(),
-                self.vao.get(),
-            );
+        if buffer.len() != expected_size || expected_size == 0 {
+            return;
         }
 
-        Propagation::Proceed
+        let stride = width as usize * BYTES_PER_PIXEL;
+
+        // CEF renders top-down in BGRA. GdkMemoryTexture expects top-down too.
+        // MemoryFormat::B8G8R8A8_PREMULTIPLIED matches CEF's BGRA output.
+        let bytes = Bytes::from(&*buffer);
+        let texture = MemoryTexture::new(
+            width,
+            height,
+            MemoryFormat::B8g8r8a8Premultiplied,
+            &bytes,
+            stride,
+        );
+
+        // Map texture to widget's CSS dimensions — GTK scales to device pixels
+        let css_width = self.obj().width() as f32;
+        let css_height = self.obj().height() as f32;
+
+        if css_width > 0.0 && css_height > 0.0 {
+            let rect = graphene::Rect::new(0.0, 0.0, css_width, css_height);
+            snapshot.append_texture(&texture, &rect);
+        }
+    }
+
+    fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
+        self.parent_size_allocate(width, height, baseline);
+
+        // Compute device pixel dimensions using fractional scale
+        let surface = self.obj().native().and_then(|n| n.surface());
+        let scale = surface.map_or(1.0, |s| s.scale());
+        let dev_w = (width as f64 * scale).round() as i32;
+        let dev_h = (height as f64 * scale).round() as i32;
+
+        if let Some(callback) = self.resize_callback.borrow().as_ref() {
+            callback(dev_w, dev_h);
+        }
     }
 }

--- a/src/app/webview/imp.rs
+++ b/src/app/webview/imp.rs
@@ -134,11 +134,6 @@ impl WidgetImpl for WebView {
         let dev_w = (width as f64 * scale).round() as i32;
         let dev_h = (height as f64 * scale).round() as i32;
 
-        tracing::debug!(
-            "size_allocate: css={}x{} scale={} -> dev={}x{}",
-            width, height, scale, dev_w, dev_h
-        );
-
         if let Some(callback) = self.resize_callback.borrow().as_ref() {
             callback(dev_w, dev_h, scale);
         }

--- a/src/app/webview/imp.rs
+++ b/src/app/webview/imp.rs
@@ -28,7 +28,7 @@ pub struct WebView {
     pub pointer_state: Rc<PointerState>,
     pub keyboard_state: Rc<KeyboardState>,
     pub frames: Box<SegQueue<Frame>>,
-    pub resize_callback: RefCell<Option<Box<dyn Fn(i32, i32)>>>,
+    pub resize_callback: RefCell<Option<Box<dyn Fn(i32, i32, f64)>>>,
 }
 
 #[glib::object_subclass]
@@ -134,8 +134,13 @@ impl WidgetImpl for WebView {
         let dev_w = (width as f64 * scale).round() as i32;
         let dev_h = (height as f64 * scale).round() as i32;
 
+        tracing::debug!(
+            "size_allocate: css={}x{} scale={} -> dev={}x{}",
+            width, height, scale, dev_w, dev_h
+        );
+
         if let Some(callback) = self.resize_callback.borrow().as_ref() {
-            callback(dev_w, dev_h);
+            callback(dev_w, dev_h, scale);
         }
     }
 }

--- a/src/app/webview/mod.rs
+++ b/src/app/webview/mod.rs
@@ -1,4 +1,3 @@
-mod gl;
 mod imp;
 
 use std::{path::PathBuf, rc::Rc};
@@ -24,7 +23,7 @@ use crate::shared::{
 
 glib::wrapper! {
     pub struct WebView(ObjectSubclass<imp::WebView>)
-        @extends gtk::GLArea, gtk::Widget,
+        @extends gtk::Widget,
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
@@ -45,9 +44,7 @@ impl WebView {
     }
 
     pub fn connect_resized<T: Fn(i32, i32) + 'static>(&self, callback: T) {
-        self.connect_resize(move |_, width, height| {
-            callback(width, height);
-        });
+        self.imp().resize_callback.replace(Some(Box::new(callback)));
     }
 
     pub fn connect_motion<T: Fn(Rc<PointerState>) + 'static>(&self, callback: T) {

--- a/src/app/webview/mod.rs
+++ b/src/app/webview/mod.rs
@@ -43,7 +43,7 @@ impl WebView {
         self.imp().frames.push(frame);
     }
 
-    pub fn connect_resized<T: Fn(i32, i32) + 'static>(&self, callback: T) {
+    pub fn connect_resized<T: Fn(i32, i32, f64) + 'static>(&self, callback: T) {
         self.imp().resize_callback.replace(Some(Box::new(callback)));
     }
 

--- a/src/app/window/mod.rs
+++ b/src/app/window/mod.rs
@@ -3,10 +3,10 @@ mod imp;
 use adw::subclass::prelude::*;
 use gtk::{
     Widget,
-    gdk::prelude::{DisplayExt, MonitorExt},
+    gdk::prelude::{DisplayExt, MonitorExt, SurfaceExt},
     gio,
     glib::{self, object::IsA},
-    prelude::{GtkWindowExt, NativeExt, WidgetExt},
+    prelude::{GtkWindowExt, NativeExt, ObjectExt, WidgetExt},
 };
 use url::Url;
 
@@ -42,7 +42,8 @@ impl Window {
         self.set_fullscreened(fullscreen);
     }
 
-    pub fn connect_monitor_info<F: Fn(f64, i32) + 'static>(&self, callback: F) {
+    pub fn connect_monitor_info<F: Fn(f64, f64) + Clone + 'static>(&self, callback: F) {
+        let realize_callback = callback.clone();
         self.connect_realize(move |window| {
             let display = window.display();
             let surface = window.surface();
@@ -51,9 +52,24 @@ impl Window {
                 && let Some(monitor) = display.monitor_at_surface(&surface)
             {
                 let refresh_rate = monitor.refresh_rate() as f64 / 1000.0;
-                let scale_factor = monitor.scale_factor();
+                let scale_factor = surface.scale();
 
-                callback(refresh_rate, scale_factor);
+                realize_callback(refresh_rate, scale_factor);
+            }
+        });
+
+        let scale_callback = callback.clone();
+        self.connect_notify_local(Some("scale-factor"), move |window, _| {
+            let display = window.display();
+            let surface = window.surface();
+
+            if let Some(surface) = surface
+                && let Some(monitor) = display.monitor_at_surface(&surface)
+            {
+                let refresh_rate = monitor.refresh_rate() as f64 / 1000.0;
+                let scale_factor = surface.scale();
+
+                scale_callback(refresh_rate, scale_factor);
             }
         });
     }

--- a/src/app/window/mod.rs
+++ b/src/app/window/mod.rs
@@ -44,6 +44,7 @@ impl Window {
 
     pub fn connect_monitor_info<F: Fn(f64, f64) + Clone + 'static>(&self, callback: F) {
         let realize_callback = callback.clone();
+        let scale_callback = callback.clone();
         self.connect_realize(move |window| {
             let display = window.display();
             let surface = window.surface();
@@ -55,21 +56,19 @@ impl Window {
                 let scale_factor = surface.scale();
 
                 realize_callback(refresh_rate, scale_factor);
-            }
-        });
 
-        let scale_callback = callback.clone();
-        self.connect_notify_local(Some("scale-factor"), move |window, _| {
-            let display = window.display();
-            let surface = window.surface();
+                // Listen for fractional scale changes on the surface
+                // (fires when moving between monitors with different scales)
+                let cb = scale_callback.clone();
+                let display = display.clone();
+                surface.connect_notify_local(Some("scale"), move |surface, _| {
+                    if let Some(monitor) = display.monitor_at_surface(surface) {
+                        let refresh_rate = monitor.refresh_rate() as f64 / 1000.0;
+                        let scale_factor = surface.scale();
 
-            if let Some(surface) = surface
-                && let Some(monitor) = display.monitor_at_surface(&surface)
-            {
-                let refresh_rate = monitor.refresh_rate() as f64 / 1000.0;
-                let scale_factor = surface.scale();
-
-                scale_callback(refresh_rate, scale_factor);
+                        cb(refresh_rate, scale_factor);
+                    }
+                });
             }
         });
     }

--- a/src/chromium/app/client/render_handler.rs
+++ b/src/chromium/app/client/render_handler.rs
@@ -21,12 +21,13 @@ wrap_render_handler! {
 
     impl RenderHandler {
         fn screen_info(&self, _browser: Option<&mut Browser>, screen_info: Option<&mut ScreenInfo>) -> i32 {
-            if let Ok(viewport) = self.viewport.read()
-                && let Some(screen_info) = screen_info {
-                    screen_info.device_scale_factor = viewport.scale_factor as f32;
-
-                    return true.into();
-                }
+            if let Some(screen_info) = screen_info {
+                // CEF OSR doesn't apply device_scale_factor to the paint buffer,
+                // so we set it to 1.0 and give device pixel dimensions directly
+                // as view_rect. DPI scaling is handled via zoom level instead.
+                screen_info.device_scale_factor = 1.0;
+                return true.into();
+            }
 
             false.into()
         }
@@ -45,8 +46,14 @@ wrap_render_handler! {
         fn view_rect(&self, _browser: Option<&mut Browser>, rect: Option<&mut Rect>) {
             if let Some(rect) = rect
                 && let Ok(viewport) = self.viewport.read() {
-                    rect.width = (viewport.width as f64 / viewport.scale_factor).round() as i32;
-                    rect.height = (viewport.height as f64 / viewport.scale_factor).round() as i32;
+                    // Return device pixel dimensions directly since
+                    // device_scale_factor is 1.0
+                    rect.width = viewport.width;
+                    rect.height = viewport.height;
+                    tracing::debug!(
+                        "view_rect: dev={}x{} scale={}",
+                        viewport.width, viewport.height, viewport.scale_factor
+                    );
                 }
         }
 
@@ -59,6 +66,7 @@ wrap_render_handler! {
             width: i32,
             height: i32,
         ) {
+            tracing::debug!("on_paint: buffer={}x{}", width, height);
             if let Some(dirty_rects) = dirty_rects {
                 for dirty_rect in dirty_rects {
                     let x = dirty_rect.x as usize;

--- a/src/chromium/app/client/render_handler.rs
+++ b/src/chromium/app/client/render_handler.rs
@@ -45,8 +45,8 @@ wrap_render_handler! {
         fn view_rect(&self, _browser: Option<&mut Browser>, rect: Option<&mut Rect>) {
             if let Some(rect) = rect
                 && let Ok(viewport) = self.viewport.read() {
-                    rect.width = viewport.width / viewport.scale_factor;
-                    rect.height = viewport.height / viewport.scale_factor;
+                    rect.width = (viewport.width as f64 / viewport.scale_factor).round() as i32;
+                    rect.height = (viewport.height as f64 / viewport.scale_factor).round() as i32;
                 }
         }
 

--- a/src/chromium/app/client/render_handler.rs
+++ b/src/chromium/app/client/render_handler.rs
@@ -46,14 +46,8 @@ wrap_render_handler! {
         fn view_rect(&self, _browser: Option<&mut Browser>, rect: Option<&mut Rect>) {
             if let Some(rect) = rect
                 && let Ok(viewport) = self.viewport.read() {
-                    // Return device pixel dimensions directly since
-                    // device_scale_factor is 1.0
                     rect.width = viewport.width;
                     rect.height = viewport.height;
-                    tracing::debug!(
-                        "view_rect: dev={}x{} scale={}",
-                        viewport.width, viewport.height, viewport.scale_factor
-                    );
                 }
         }
 
@@ -66,7 +60,6 @@ wrap_render_handler! {
             width: i32,
             height: i32,
         ) {
-            tracing::debug!("on_paint: buffer={}x{}", width, height);
             if let Some(dirty_rects) = dirty_rects {
                 for dirty_rect in dirty_rects {
                     let x = dirty_rect.x as usize;

--- a/src/chromium/mod.rs
+++ b/src/chromium/mod.rs
@@ -139,7 +139,7 @@ impl Chromium {
         self.receiver.try_iter().for_each(handler);
     }
 
-    pub fn set_monitor_info(&self, refresh_rate: f64, scale_factor: i32) {
+    pub fn set_monitor_info(&self, refresh_rate: f64, scale_factor: f64) {
         if let Ok(mut viewport) = self.viewport.write() {
             viewport.scale_factor = scale_factor;
         }
@@ -147,6 +147,7 @@ impl Chromium {
         if let Some(browser_host) = self.browser_host() {
             browser_host.set_windowless_frame_rate(refresh_rate.min(MAX_FRAME_RATE) as i32);
             browser_host.notify_screen_info_changed();
+            browser_host.was_resized();
         }
     }
 
@@ -154,11 +155,11 @@ impl Chromium {
         if let Ok(mut viewport) = self.viewport.write() {
             viewport.width = width;
             viewport.height = height;
+        }
 
-            if let Some(browser_host) = self.browser_host() {
-                browser_host.was_resized();
-                browser_host.invalidate(PET_VIEW.into());
-            }
+        if let Some(browser_host) = self.browser_host() {
+            browser_host.was_resized();
+            browser_host.invalidate(PET_VIEW.into());
         }
     }
 

--- a/src/chromium/mod.rs
+++ b/src/chromium/mod.rs
@@ -151,13 +151,24 @@ impl Chromium {
         }
     }
 
-    pub fn resize(&self, width: i32, height: i32) {
+    pub fn resize(&self, width: i32, height: i32, scale_factor: f64) {
         if let Ok(mut viewport) = self.viewport.write() {
             viewport.width = width;
             viewport.height = height;
+            viewport.scale_factor = scale_factor;
         }
 
         if let Some(browser_host) = self.browser_host() {
+            // DPI compensation: CEF renders at device pixel dimensions (view_rect)
+            // with device_scale_factor=1. Use zoom level to make content layout
+            // at the correct CSS pixel size.
+            // Formula: zoom_percent = 100 * 1.2^level, so level = ln(scale) / ln(1.2)
+            if scale_factor > 0.0 {
+                let zoom_level = scale_factor.ln() / 1.2_f64.ln();
+                browser_host.set_zoom_level(zoom_level);
+            }
+
+            browser_host.notify_screen_info_changed();
             browser_host.was_resized();
             browser_host.invalidate(PET_VIEW.into());
         }

--- a/src/chromium/mod.rs
+++ b/src/chromium/mod.rs
@@ -186,9 +186,20 @@ impl Chromium {
         }
     }
 
+    // Scale GTK CSS pixel coordinates to device pixel coordinates for CEF,
+    // since view_rect is in device pixels with device_scale_factor=1.
+    fn scaled_mouse_event(&self, pointer_state: &PointerState) -> MouseEvent {
+        let mut event = MouseEvent::from(pointer_state);
+        if let Ok(viewport) = self.viewport.read() {
+            event.x = (event.x as f64 * viewport.scale_factor).round() as i32;
+            event.y = (event.y as f64 * viewport.scale_factor).round() as i32;
+        }
+        event
+    }
+
     pub fn forward_motion(&self, pointer_state: &PointerState) {
         if let Some(browser_host) = self.browser_host() {
-            let mouse_event = MouseEvent::from(pointer_state);
+            let mouse_event = self.scaled_mouse_event(pointer_state);
             let mouse_leave = (!pointer_state.over()).into();
             browser_host.send_mouse_move_event(Some(&mouse_event), mouse_leave);
         }
@@ -196,7 +207,7 @@ impl Chromium {
 
     pub fn forward_scroll(&self, pointer_state: &PointerState, delta_x: f64, delta_y: f64) {
         if let Some(browser_host) = self.browser_host() {
-            let mouse_event = MouseEvent::from(pointer_state);
+            let mouse_event = self.scaled_mouse_event(pointer_state);
 
             browser_host.send_mouse_wheel_event(Some(&mouse_event), delta_x as i32, delta_y as i32);
         }
@@ -207,7 +218,7 @@ impl Chromium {
             let pressed = pointer_state.pressed();
             let button = pointer_state.button();
 
-            let mouse_event = MouseEvent::from(pointer_state);
+            let mouse_event = self.scaled_mouse_event(pointer_state);
 
             let r#type = match button {
                 1 => Some(MBT_LEFT.into()),
@@ -257,7 +268,7 @@ impl Chromium {
             if let Some(mut drag_data) = cef::drag_data_create() {
                 drag_data.add_file(file_path.as_ref(), file_name.as_ref());
 
-                let mouse_event = MouseEvent::from(pointer_state);
+                let mouse_event = self.scaled_mouse_event(pointer_state);
 
                 browser_host.drag_target_drag_enter(
                     Some(&mut drag_data),
@@ -270,7 +281,7 @@ impl Chromium {
 
     pub fn forward_file_hover(&self, pointer_state: &PointerState) {
         if let Some(browser_host) = self.browser_host() {
-            let mouse_event = MouseEvent::from(pointer_state);
+            let mouse_event = self.scaled_mouse_event(pointer_state);
 
             browser_host.drag_target_drag_over(
                 Some(&mouse_event),
@@ -281,7 +292,7 @@ impl Chromium {
 
     pub fn forward_file_drop(&self, pointer_state: &PointerState) {
         if let Some(browser_host) = self.browser_host() {
-            let mouse_event = MouseEvent::from(pointer_state);
+            let mouse_event = self.scaled_mouse_event(pointer_state);
 
             browser_host.drag_target_drop(Some(&mouse_event));
         }

--- a/src/chromium/types.rs
+++ b/src/chromium/types.rs
@@ -2,7 +2,7 @@
 pub struct Viewport {
     pub width: i32,
     pub height: i32,
-    pub scale_factor: i32,
+    pub scale_factor: f64,
 }
 
 impl Default for Viewport {
@@ -10,7 +10,7 @@ impl Default for Viewport {
         Self {
             width: 1700,
             height: 1004,
-            scale_factor: 1,
+            scale_factor: 1.0,
         }
     }
 }


### PR DESCRIPTION
I've been experiencing scaling issues such as:
- blurriness on scaled displays
- scale not changing between scaled and unscaled displays
- cursor offsets

I have no idea how to debug and fix all these issues on my own so I used Claude Opus 4.6. Here's its summary:

  Root cause: CEF's OSR mode ignores `device_scale_factor` for paint buffer size — it always renders at 1×  `view_rect` dimensions. The old `GLArea` code upscaled this via GL, and fractional scaling made it worse.

  Solution (across all commits):

   1. Widget + `GdkMemoryTexture` replaces `GLArea` — CPU frame buffer with dirty rect blitting, rendered via GTK's snapshot pipeline at exact fractional scale
   2. `view_rect` = device pixels with `device_scale_factor=1` — CEF renders at native resolution
   3. Zoom level = `ln(scale)/ln(1.2)` — compensates DPI so content layouts at correct CSS size
   4. Mouse coordinates × scale — transforms GTK CSS coords to device pixel coords for CEF
   5. Surface `scale` property listener — detects fractional scale changes when moving between monitors
   6. `queue_allocate()` on scale change — forces recomputation of device pixel dimensions
   
I don't know whether this code is robust or pragmatic, and some of the changes feel intrusive. Feel free to change in any way necessary.