### PR TITLE
perf: reduce idle CPU usage by switching to event-driven loop

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -351,6 +351,7 @@ impl ApplicationHandler<UserEvent> for App {
             UserEvent::Quit => {
                 event_loop.exit();
             }
+            UserEvent::Redraw => {}
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,9 +82,10 @@ fn main() -> ExitCode {
         .build()
         .expect("Failed to create event loop");
 
-    event_loop.set_control_flow(ControlFlow::Poll);
+    event_loop.set_control_flow(ControlFlow::Wait);
 
     let event_loop_proxy = event_loop.create_proxy();
+    shared::EVENT_LOOP_PROXY.set(event_loop_proxy.clone()).ok();
 
     let mut needs_redraw = false;
 

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -212,6 +212,7 @@ impl Player {
         let sender = self.sender.clone();
         render_context.set_update_callback(move || {
             sender.send(PlayerEvent::Update).ok();
+            crate::shared::wake_event_loop();
         });
 
         self.render_context = Some(render_context);

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -6,6 +6,19 @@ use std::{
     sync::{Mutex, RwLock},
 };
 
+use once_cell::sync::OnceCell;
+use winit::event_loop::EventLoopProxy;
+
+use self::types::UserEvent;
+
+pub static EVENT_LOOP_PROXY: OnceCell<EventLoopProxy<UserEvent>> = OnceCell::new();
+
+pub fn wake_event_loop() {
+    if let Some(proxy) = EVENT_LOOP_PROXY.get() {
+        proxy.send_event(UserEvent::Redraw).ok();
+    }
+}
+
 use glutin::{
     context::{NotCurrentContext, PossiblyCurrentContext},
     prelude::{NotCurrentGlContext, PossiblyCurrentGlContext},

--- a/src/shared/types.rs
+++ b/src/shared/types.rs
@@ -47,4 +47,5 @@ pub enum UserEvent {
     Show,
     Hide,
     Quit,
+    Redraw,
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -40,7 +40,7 @@ impl Tray {
             let menu = Self::create_menu();
             let tray = Self::create(menu, config);
 
-            glib::timeout_add_local(Duration::from_millis(16), move || {
+            glib::timeout_add_local(Duration::from_millis(100), move || {
                 tray_receiver.try_iter().for_each(|event| match event {
                     TrayEvent::Visibility(state) => {
                         let menu = Self::create_menu();

--- a/src/webview/app/client/render_handler.rs
+++ b/src/webview/app/client/render_handler.rs
@@ -55,6 +55,7 @@ cef_impl!(
 
                         if let Some(sender) = SENDER.get() {
                             sender.send(WebViewEvent::Paint).ok();
+                            crate::shared::wake_event_loop();
                         }
                     } else if let Some(sender) = SENDER.get() {
                         sender.send(WebViewEvent::Resized).ok();


### PR DESCRIPTION
## Summary

   - Resolves https://github.com/Stremio/stremio-linux-shell/issues/4
   - Replace `ControlFlow::Poll` with `ControlFlow::Wait` so the main loop sleeps until a real event arrives instead of spinning unconditionally
   - Add a shared `EventLoopProxy` static (`wake_event_loop()`) so background threads can wake the main loop on demand
   - CEF's `on_paint` and mpv's render update callback now call `wake_event_loop()` to unblock the loop when there's actual work
   - Reduce the GTK tray poll timer from 16ms (62.5 fps) to 100ms