### PR TITLE
fix(server): default SERVER_PATH at compile time

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -16,7 +16,11 @@ pub struct Server {
 
 impl Server {
     pub fn new() -> Self {
-        let server_path = env::var("SERVER_PATH").expect("Failed to read SERVER_PATH env");
+        let server_path = env::var("SERVER_PATH").unwrap_or_else(|_| {
+            option_env!("SERVER_PATH")
+                .unwrap_or("data/server.js")
+                .to_string()
+        });
         let file = PathBuf::from(&server_path);
 
         Self {


### PR DESCRIPTION
Building the application according to the README, and then running it from the `target/release` directory resulted in a `"Failed to read SERVER_PATH"` panic on startup.

This PR sets a fall back to `data/server.js` (while still respecting the `.cargo/config.toml` and environment variables).

Another option would be to adjust the README about this behavior I guess.