### PR TITLE
fix(app/tray): Avoid panic when failing to create tray icon

### DIFF
--- a/src/app/tray/imp.rs
+++ b/src/app/tray/imp.rs
@@ -8,6 +8,7 @@ use gtk::{
 };
 use ksni::{Handle, MenuItem, TrayMethods, menu::StandardItem};
 use tokio::sync::Mutex;
+use tracing::error;
 
 use crate::{
     app::{
@@ -66,12 +67,14 @@ impl ObjectImpl for Tray {
         let local_handle = self.handle.clone();
         tokio::spawn(async move {
             let mut handle_guard = local_handle.lock().await;
-            let handle = tray_icon
+            *handle_guard = tray_icon
                 .disable_dbus_name(true)
                 .spawn()
                 .await
-                .expect("Failed to create tray icon");
-            *handle_guard = Some(handle);
+                .inspect_err(|err| {
+                    error!("Failed to create tray icon: {err}");
+                })
+                .ok()
         });
 
         spawn_local!(clone!(


### PR DESCRIPTION
Hi, this is a dumb change to the app.

My desktop environment doesn't have a tray, so the imp::Tray::construct function fails to initialize the Handle. 
This is not a problem, since the app works perfectly. But  I noticed this panic message.
```
thread 'tokio-rt-worker' (35925) panicked at src/app/tray/imp.rs:73:18:
Failed to create tray icon: Watcher(ServiceUnknown("The name is not activatable"))
```
handle_guard is an Option, that gets assigned the Handle on line 69.
Instead of expecting the Result, I think it's better to log the error, and leave handle_guard as None.

The new output would be:
```
Failed to create tray icon: failed to register to the StatusNotifierWatcher:
        org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
```

**Please note** that I don't have a tray, so it would be nice if someone with a DE that supports tray icons checked that everything works. I suppose it does, since the state of the handle_guard remains the same as before. It gets set to None. The only change in behavior is that now the function prints an error instead of panicking.
