### PR TITLE
fix(ipc): guard webChannelTransport.onmessage before invoking

### DIFF
--- a/src/app/ipc/preload.js
+++ b/src/app/ipc/preload.js
@@ -54,7 +54,9 @@ globalThis.chrome = {
 };
 
 window.ipc.addEventListener('message', (message) => {
-    window.qt.webChannelTransport.onmessage(message);
+    if (typeof window.qt.webChannelTransport.onmessage === 'function') {
+        window.qt.webChannelTransport.onmessage(message);
+    }
 });
 
 console.log('IPC script injected');


### PR DESCRIPTION
### Problem

The preload script (`src/app/ipc/preload.js`) unconditionally calls `window.qt.webChannelTransport.onmessage(message)` inside its `message` listener, but the transport shim in the same file only assigns `.send`. `.onmessage` is expected to be installed later by the hosted stremio-web app.

If a message arrives from the shell before (or without) the web app assigning `.onmessage`, the listener throws:

```
TypeError: undefined is not a function
```

which the Rust side surfaces at startup as:

```
ERROR stremio_linux_shell::app::webview: Failed to send message: TypeError: undefined is not a function
```

This is one of the errors reported in #68 / #73 / stremio-bugs#2646 and appears in every session on affected setups (Fedora 44 + AMD + GNOME/Wayland, but not limited to that combo — same log line appears in CachyOS + AMD reports).

### Fix

Guard the call with a `typeof` check. When the transport hasn't been fully initialized, the listener is now a no-op instead of throwing. Once stremio-web installs its `onmessage` handler, behavior is unchanged.

```diff
 window.ipc.addEventListener('message', (message) => {
-    window.qt.webChannelTransport.onmessage(message);
+    if (typeof window.qt.webChannelTransport.onmessage === 'function') {
+        window.qt.webChannelTransport.onmessage(message);
+    }
 });
```

### Notes

- Scope is intentionally minimal — silences the spurious error only. Does not address the mpv VO init failure or the "audio keeps playing after quit" behavior reported in the same tickets; those are separate.
- No regression once `.onmessage` is assigned: `typeof` check passes and the message is delivered as before.
- Messages that would previously have thrown are now dropped silently. This matches the intent — if there's no handler to receive them, throwing was never useful.

Refs #68, #73.