### PR TITLE
fix: cut playback CPU usage with zero-copy hardware decoding and the GL GSK renderer

### DIFF
--- a/src/app/video/imp.rs
+++ b/src/app/video/imp.rs
@@ -37,6 +37,13 @@ impl Default for Video {
             init.set_property("vo", "libmpv")?;
             init.set_property("video-timing-offset", "0")?;
             init.set_property("video-sync", "audio")?;
+            // Enable zero-copy hardware decoding by default. mpv otherwise
+            // defaults to software decoding, and the web UI only ever asks for
+            // the copy-back path (`hwdec=auto-copy`, remapped in mod.rs). Our GL
+            // render context is created with the Wayland display, so mpv can use
+            // the EGL/dmabuf interop (VAAPI on Mesa) and keep frames on the GPU.
+            // `auto-safe` falls back to software when no safe interop exists.
+            init.set_property("hwdec", "auto-safe")?;
             init.set_property("terminal", "yes")?;
             init.set_property("msg-level", msg_level)?;
             Ok(())

--- a/src/app/video/mod.rs
+++ b/src/app/video/mod.rs
@@ -107,6 +107,23 @@ impl Video {
             }
             name if STRING_PROPERTIES.contains(&name) => {
                 if let Some(value) = value.as_str() {
+                    // The Stremio web UI enables hardware decoding by sending
+                    // `hwdec=auto-copy`. That decodes on the GPU but copies every
+                    // frame back to system memory and re-uploads it for rendering
+                    // (the "copy-back" path), which is CPU- and bandwidth-heavy —
+                    // the reason playback here costs more CPU than mpv/VLC. Our
+                    // render context is created with the Wayland display, so mpv
+                    // can keep frames on the GPU via a zero-copy interop (VAAPI,
+                    // Vulkan, NVDEC, ... depending on the driver) instead. Remap
+                    // to `auto-safe`, which uses such an interop when a known-good
+                    // one is available and otherwise falls back to software
+                    // decoding, so playback can never break.
+                    let value = if name == "hwdec" && value == "auto-copy" {
+                        "auto-safe"
+                    } else {
+                        value
+                    };
+
                     widget.set_property(name, value);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,24 @@ struct Args {
 }
 
 fn main() -> ExitCode {
+    // GTK 4.22 defaults to the Vulkan GSK renderer. Compositing our OpenGL video
+    // GLArea through it forces a per-frame GL->Vulkan copy, which dominates
+    // playback CPU even when hardware decoding is active. Prefer the GL renderer,
+    // unless a renderer was already chosen — data/stremio.sh sets `opengl` for
+    // Nvidia, and `opengl` and `gl` are the same renderer here, so the two compose.
+    // Must be set before GTK initializes.
+    //
+    // The name is `gl`: GTK renamed the new GL renderer in 4.18. `ngl` still
+    // resolves to it as a deprecated alias, but warns. Any name GTK does not
+    // recognize falls back to the Vulkan renderer this is meant to avoid, so the
+    // value is worth keeping in step with `GSK_RENDERER=help`.
+    //
+    // SAFETY: this runs at the very start of main, before any other threads are
+    // spawned, so there is no concurrent access to the environment.
+    if env::var_os("GSK_RENDERER").is_none() {
+        unsafe { env::set_var("GSK_RENDERER", "gl") };
+    }
+
     tracing_subscriber::fmt::init();
 
     let data_dir = dirs::data_dir()


### PR DESCRIPTION
Playback in the GTK4 shell costs several times more CPU than mpv or VLC playing the same file. Following the review request this PR is now reduced to the playback fixes only, three commits. The idle CPU fix moved to #120 and the NVIDIA specific fix to #121.

Should fix #103 and possibly #107.

## What is in this PR

**Decoding ran on the CPU.** mpv defaults to software decoding unless `hwdec` is set. The shell set no default and only received `hwdec` from the web UI at runtime, after the render context already existed, which did not reliably bring up the GL hwdec interop. `hwdec=auto-safe` is now set in the initializer, so mpv loads the zero copy interop when the render context is created:

```
[libmpv_render] Loading hwdec driver 'vaapi'
[libmpv_render/vaapi] Using EGL dmabuf interop via GL_OES_EGL_image
```

**Hardware decoding was copy back.** The web UI enables hardware decoding by sending `hwdec=auto-copy`, which decodes on the GPU, copies every frame back to system memory and re-uploads it for rendering. That copy is CPU and bandwidth heavy. `auto-copy` is remapped to `auto-safe`, which keeps frames on the GPU through a zero copy interop and still falls back to software decoding when no known good one exists, so playback cannot break.

**The Vulkan GSK renderer composited an OpenGL GLArea.** GTK 4.22 defaults to the Vulkan renderer. The video is an OpenGL `GLArea` from mpv's `vo=libmpv` render API, and compositing a GL texture through the Vulkan renderer forces a per frame GL to Vulkan copy that dominates playback CPU even with hardware decoding active. `GSK_RENDERER` now defaults to `gl` before GTK initializes, and only when the variable is unset, so a renderer chosen by the user or by `data/stremio.sh` still wins.

## Measurements

AMD Radeon 680M, Mesa, GTK 4.22.4, libmpv 0.41 in the Devel flatpak, machine otherwise idle.

Renderer, measured with a probe that reproduces the shell's render path, a GLArea plus a libmpv render context with no WebKit and no server, 1080p30 H.264 with vaapi confirmed active and 30.0 fps held in both arms. Medians of three interleaved 12 s windows after warmup:

| renderer | CPU |
| --- | --: |
| vulkan, the GTK 4.22 default | 31.3% |
| gl, this PR | 6.3% |

Decode path, same probe, renderer held at gl:

| requested hwdec | what mpv selected | CPU |
| --- | --- | --: |
| no, the behaviour before this PR | software | 26.2% |
| auto-copy, what the web UI sends today | vulkan-copy | 9.4% |
| auto-safe, this PR | vaapi | 6.3% |

Real app, 4K HDR HEVC at 3840x2160 p010 BT.2020 PQ, same title and same screen, CPU of the `stremio` process over 30 s:

| hwdec | mpv decode line | VO format | CPU |
| --- | --- | --- | --: |
| auto-copy | Using hardware decoding (vulkan-copy). | VO: [libmpv] 3840x2160 p010 | 25.9% |
| auto-safe | Using hardware decoding (vaapi). | VO: [libmpv] 3840x2160 vaapi[p010] | 11.6% |

The VO line is the clearest signal of what the remap buys. With `auto-safe` a hardware surface reaches the libmpv VO, with `auto-copy` a system memory frame does.

@KemalK tested an earlier revision of this branch on Intel Meteor Lake, Fedora 43, and reported playback going from about 2.5 cores to about 0.3 core with idle CPU from about 0.3 to about 0.05, details in the comments below.

## Notes

- `gl` and `opengl` are the same renderer in GTK 4.22, both map to `GSK_TYPE_GL_RENDERER` in `gsk/gskrenderer.c`. What was removed in 4.18 is the old GL renderer. `data/stremio.sh` setting `opengl` on NVIDIA already selects the renderer this PR defaults to, so nothing changes there.
- With `GSK_RENDERER` unset GTK tries Vulkan first, `renderer_possibilities[]` lists it ahead of GL, which is what makes this the default path today.
- `env::set_var` is unsafe under edition 2024. It runs at the very top of `main` before any thread is spawned, so there is no concurrent access to the environment.
- The probe used for these numbers is deliberately not part of this PR. It lives on the [`cpu-debug`](https://github.com/AltarBeastiful/stremio-linux-shell/tree/cpu-debug) branch in my fork.
