### PR TITLE
Fix Tokio runtime context during app run

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -45,7 +45,7 @@ impl Application {
             .build()
     }
 
-    pub async fn run(&self, args: Vec<String>) -> ExitCode {
+    pub fn run(&self, args: Vec<String>) -> ExitCode {
         let mut program = std::env::args().take(1).collect_vec();
         program.extend(args);
         self.run_with_args(&program)

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,5 +71,6 @@ fn main() -> ExitCode {
     app.set_property("decorations", !args.no_window_decorations);
 
     let runtime = Runtime::new().expect("Failed to create Tokio runtime");
-    runtime.block_on(app.run(args.trailing))
+    let _guard = runtime.enter();
+    app.run(args.trailing)
 }


### PR DESCRIPTION
`run_with_args` blocks on GTK's event loop, but is called in an `async fn`. This causes tokio to stall in random places because the task never wakes up

PR moves event loop outside of a tokio async task