### PR TITLE
fix(video): stop busy-polling the mpv event and render loops

### DIFF
--- a/src/app/video/imp.rs
+++ b/src/app/video/imp.rs
@@ -14,6 +14,10 @@ use libmpv2::{
 use std::{cell::RefCell, env, os::raw::c_void, sync::OnceLock};
 use tracing::error;
 
+use crate::spawn_local;
+
+const EVENT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(16);
+
 fn get_proc_address(_context: &GLContext, name: &str) -> *mut c_void {
     epoxy::get_proc_addr(name) as _
 }
@@ -53,13 +57,17 @@ impl Default for Video {
 }
 
 impl Video {
-    fn on_event<T: Fn(Event)>(&self, callback: T) {
-        if let Some(result) = self.mpv.borrow_mut().wait_event(0.0) {
-            match result {
-                Ok(event) => callback(event),
-                Err(e) => error!("Failed to wait for event: {e}"),
+    fn process_events<T: Fn(Event)>(&self, callback: T) {
+        loop {
+            match self.mpv.borrow_mut().wait_event(0.0) {
+                Some(Ok(event)) => callback(event),
+                Some(Err(e)) => {
+                    error!("Failed to wait for event: {e}");
+                    break;
+                }
+                None => break,
             }
-        };
+        }
     }
 
     pub fn send_command(&self, name: &str, args: &[&str]) {
@@ -107,45 +115,48 @@ impl ObjectImpl for Video {
     fn constructed(&self) {
         self.parent_constructed();
 
-        glib::idle_add_local(clone!(
-            #[weak(rename_to = video)]
-            self,
-            #[weak(rename_to = object)]
-            self.obj(),
-            #[upgrade_or]
-            ControlFlow::Break,
-            move || {
-                video.on_event(|event| match event {
-                    Event::PropertyChange { name, change, .. } => {
-                        let value = match change {
-                            PropertyData::Str(v) => Some(v.to_variant()),
-                            PropertyData::Flag(v) => Some(v.to_variant()),
-                            PropertyData::Double(v) => Some(v.to_variant()),
-                            _ => None,
-                        };
+        glib::timeout_add_local(
+            EVENT_POLL_INTERVAL,
+            clone!(
+                #[weak(rename_to = video)]
+                self,
+                #[weak(rename_to = object)]
+                self.obj(),
+                #[upgrade_or]
+                ControlFlow::Break,
+                move || {
+                    video.process_events(|event| match event {
+                        Event::PropertyChange { name, change, .. } => {
+                            let value = match change {
+                                PropertyData::Str(v) => Some(v.to_variant()),
+                                PropertyData::Flag(v) => Some(v.to_variant()),
+                                PropertyData::Double(v) => Some(v.to_variant()),
+                                _ => None,
+                            };
 
-                        if let Some(value) = value {
-                            object.emit_by_name::<()>("property-changed", &[&name, &value]);
+                            if let Some(value) = value {
+                                object.emit_by_name::<()>("property-changed", &[&name, &value]);
+                            }
                         }
-                    }
-                    Event::EndFile(reason) => {
-                        let reason = match reason {
-                            mpv_end_file_reason::Eof => "eof".to_string(),
-                            mpv_end_file_reason::Stop => "stop".to_string(),
-                            mpv_end_file_reason::Redirect => "redirect".to_string(),
-                            mpv_end_file_reason::Error => "error".to_string(),
-                            mpv_end_file_reason::Quit => "quit".to_string(),
-                            _ => "other".to_string(),
-                        };
+                        Event::EndFile(reason) => {
+                            let reason = match reason {
+                                mpv_end_file_reason::Eof => "eof".to_string(),
+                                mpv_end_file_reason::Stop => "stop".to_string(),
+                                mpv_end_file_reason::Redirect => "redirect".to_string(),
+                                mpv_end_file_reason::Error => "error".to_string(),
+                                mpv_end_file_reason::Quit => "quit".to_string(),
+                                _ => "other".to_string(),
+                            };
 
-                        object.emit_by_name::<()>("playback-ended", &[&reason]);
-                    }
-                    _ => {}
-                });
+                            object.emit_by_name::<()>("playback-ended", &[&reason]);
+                        }
+                        _ => {}
+                    });
 
-                ControlFlow::Continue
-            }
-        ));
+                    ControlFlow::Continue
+                }
+            ),
+        );
     }
 }
 
@@ -186,17 +197,15 @@ impl WidgetImpl for Video {
 
             let (sender, receiver) = flume::unbounded::<()>();
 
-            glib::idle_add_local(clone!(
+            spawn_local!(clone!(
                 #[weak]
                 object,
-                #[upgrade_or]
-                ControlFlow::Break,
-                move || {
-                    if let Ok(()) = receiver.try_recv() {
+                async move {
+                    while receiver.recv_async().await.is_ok() {
+                        while receiver.try_recv().is_ok() {}
+
                         object.queue_render();
                     }
-
-                    ControlFlow::Continue
                 }
             ));
 


### PR DESCRIPTION
Split out of #108 so each fix can be reviewed on its own, as requested. This one is the idle CPU fix, one commit. The playback fixes stay in #108.

Two `glib::idle_add_local` sources ran on every main loop iteration, one polling mpv's event queue with `wait_event(0.0)` and one polling a flume channel with `try_recv()`. An idle source is always ready, so the main loop never blocks and both spin continuously, burning CPU when the app is doing nothing.

That behaviour comes straight from GLib, in `glib/gmain.c`:

```c
static gboolean g_idle_prepare (GSource *source, gint *timeout) { *timeout = 0; return TRUE; }
static gboolean g_idle_check   (GSource *source)                 { return TRUE; }
```

`prepare` returns TRUE with a zero timeout, so `poll` is called with a zero timeout on every iteration and the loop cannot sleep. The `G_PRIORITY_DEFAULT_IDLE` priority only orders the callback within an iteration, it does not make the loop wait for a quiet moment.

This drains the mpv queue from a `timeout` source at about 60 Hz, fully each tick rather than one event per iteration, and replaces the render poll with a task awaiting `recv_async()` that coalesces a burst of update callbacks into a single `queue_render()`.

`mpv_set_wakeup_callback` is deliberately not used to drive this. It is a best effort hint, mpv coalesces property changes and fires once for several events, and it races with `wait_event` clearing the pending flag. Relying on it alone latches after the first burst, so StartFile, property changes and EndFile never reach the web UI and playback sits on the loading screen.

## Measurement

AMD Radeon 680M, Mesa, GTK 4.22.4. Same binary with only this commit reverted for the before build. Idle app, no playback, CPU of the `stremio` process sampled over 15 s, five rounds each, screen on:

| build | idle CPU | poll syscalls per second |
| --- | --: | --: |
| before | 24.1% | ~6500 |
| after | 0.5% | ~74 |

The timer does cost about 0.5% where a fully event driven loop would cost close to nothing. That is the trade for not depending on the wakeup callback. If you would rather have fewer idle wakeups I am happy to make the interval adaptive, for example a slower tick while nothing is playing.
