### PR TITLE
fix(hwdec): zero-copy nvdec on NVIDIA, 4K HDR from ~100% to ~23% of a core

### DIFF
--- a/src/app/video/imp.rs
+++ b/src/app/video/imp.rs
@@ -37,6 +37,13 @@ impl Default for Video {
             init.set_property("vo", "libmpv")?;
             init.set_property("video-timing-offset", "0")?;
             init.set_property("video-sync", "audio")?;
+            // Enable zero-copy hardware decoding by default. mpv otherwise
+            // defaults to software decoding, and the web UI only ever asks for
+            // the copy-back path (`hwdec=auto-copy`, remapped in mod.rs). Our GL
+            // render context is created with the Wayland display, so mpv can use
+            // the EGL/dmabuf interop (VAAPI on Mesa) and keep frames on the GPU.
+            // `auto-safe` falls back to software when no safe interop exists.
+            init.set_property("hwdec", "auto-safe")?;
             init.set_property("terminal", "yes")?;
             init.set_property("msg-level", msg_level)?;
             Ok(())

--- a/src/app/video/imp.rs
+++ b/src/app/video/imp.rs
@@ -33,17 +33,16 @@ impl Default for Video {
             _ => "all=no",
         };
 
+        // Enable zero-copy hardware decoding by default (see `super::default_hwdec`).
+        // mpv otherwise defaults to software decoding, and the web UI only asks for
+        // copy-back (`hwdec=auto-copy`, remapped in mod.rs).
+        let hwdec = super::default_hwdec();
+
         let mpv = Mpv::with_initializer(|init| {
             init.set_property("vo", "libmpv")?;
             init.set_property("video-timing-offset", "0")?;
             init.set_property("video-sync", "audio")?;
-            // Enable zero-copy hardware decoding by default. mpv otherwise
-            // defaults to software decoding, and the web UI only ever asks for
-            // the copy-back path (`hwdec=auto-copy`, remapped in mod.rs). Our GL
-            // render context is created with the Wayland display, so mpv can use
-            // the EGL/dmabuf interop (VAAPI on Mesa) and keep frames on the GPU.
-            // `auto-safe` falls back to software when no safe interop exists.
-            init.set_property("hwdec", "auto-safe")?;
+            init.set_property("hwdec", hwdec.as_str())?;
             init.set_property("terminal", "yes")?;
             init.set_property("msg-level", msg_level)?;
             Ok(())

--- a/src/app/video/mod.rs
+++ b/src/app/video/mod.rs
@@ -10,6 +10,35 @@ use tracing::warn;
 
 use crate::app::video::config::{BOOL_PROPERTIES, FLOAT_PROPERTIES, STRING_PROPERTIES};
 
+/// The `hwdec` mode to request. Zero-copy keeps decoded frames on the GPU — a
+/// large CPU/bandwidth win (measured ~100% -> ~23% of a core on 4K HDR); copy-back
+/// (`*-copy`) round-trips every frame through system RAM.
+///
+/// - **Mesa (AMD/Intel):** `auto-safe` selects VAAPI dmabuf zero-copy.
+/// - **Nvidia proprietary:** `auto-safe` only offers copy-back (`vulkan-copy`),
+///   so request `nvdec` explicitly for CUDA-interop zero-copy. Verified clean and
+///   ~4x cheaper than copy-back on 4K HDR. (Earlier reports of `nvdec` artifacts
+///   were a host-only libmpv build issue; see BENCHMARKS.md / DEVLOG.)
+///
+/// REQUIRES libmpv built with the CUDA interop, else `nvdec` falls back to
+/// copy-back/software: mpv `--enable-cuda-hwaccel --enable-cuda-interop`, ffmpeg
+/// with `--enable-ffnvcodec` (nvdec), and `libplacebo`. Verified with libmpv
+/// 0.41 / ffmpeg 7.1 (org.gnome.Platform 50 runtime). Distro `libmpv` packages
+/// (e.g. for the .deb) must ship these features for the Nvidia win to apply.
+///
+/// `STREMIO_HWDEC` overrides everything (e.g. `nvdec`, `auto-safe`, `auto-copy`,
+/// `no`) for testing decode modes without a rebuild.
+fn default_hwdec() -> String {
+    std::env::var("STREMIO_HWDEC").unwrap_or_else(|_| {
+        if std::path::Path::new("/dev/nvidia0").exists() {
+            "nvdec"
+        } else {
+            "auto-safe"
+        }
+        .to_string()
+    })
+}
+
 glib::wrapper! {
     pub struct Video(ObjectSubclass<imp::Video>)
         @extends gtk::GLArea, gtk::Widget,
@@ -107,22 +136,13 @@ impl Video {
             }
             name if STRING_PROPERTIES.contains(&name) => {
                 if let Some(value) = value.as_str() {
-                    // The Stremio web UI enables hardware decoding by sending
-                    // `hwdec=auto-copy`. That decodes on the GPU but copies every
-                    // frame back to system memory and re-uploads it for rendering
-                    // (the "copy-back" path), which is CPU- and bandwidth-heavy —
-                    // the reason playback here costs more CPU than mpv/VLC. Our
-                    // render context is created with the Wayland display, so mpv
-                    // can keep frames on the GPU via a zero-copy interop (VAAPI,
-                    // Vulkan, NVDEC, ... depending on the driver) instead. Remap
-                    // to `auto-safe`, which uses such an interop when a known-good
-                    // one is available and otherwise falls back to software
-                    // decoding, so playback can never break.
-                    let value = if name == "hwdec" && value == "auto-copy" {
-                        "auto-safe"
-                    } else {
-                        value
-                    };
+                    // The web UI enables hardware decoding by sending
+                    // `hwdec=auto-copy` (copy-back: decode on the GPU, copy every
+                    // frame back to system RAM and re-upload it — CPU/bandwidth
+                    // heavy, ~30x costlier than zero-copy on 4K HDR). Remap it to
+                    // the platform's zero-copy mode (`super::default_hwdec`).
+                    let hwdec = (name == "hwdec" && value == "auto-copy").then(default_hwdec);
+                    let value = hwdec.as_deref().unwrap_or(value);
 
                     widget.set_property(name, value);
                 }

--- a/src/app/video/mod.rs
+++ b/src/app/video/mod.rs
@@ -107,6 +107,23 @@ impl Video {
             }
             name if STRING_PROPERTIES.contains(&name) => {
                 if let Some(value) = value.as_str() {
+                    // The Stremio web UI enables hardware decoding by sending
+                    // `hwdec=auto-copy`. That decodes on the GPU but copies every
+                    // frame back to system memory and re-uploads it for rendering
+                    // (the "copy-back" path), which is CPU- and bandwidth-heavy —
+                    // the reason playback here costs more CPU than mpv/VLC. Our
+                    // render context is created with the Wayland display, so mpv
+                    // can keep frames on the GPU via a zero-copy interop (VAAPI,
+                    // Vulkan, NVDEC, ... depending on the driver) instead. Remap
+                    // to `auto-safe`, which uses such an interop when a known-good
+                    // one is available and otherwise falls back to software
+                    // decoding, so playback can never break.
+                    let value = if name == "hwdec" && value == "auto-copy" {
+                        "auto-safe"
+                    } else {
+                        value
+                    };
+
                     widget.set_property(name, value);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,24 @@ struct Args {
 }
 
 fn main() -> ExitCode {
+    // GTK 4.22 defaults to the Vulkan GSK renderer. Compositing our OpenGL video
+    // GLArea through it forces a per-frame GL->Vulkan copy, which dominates
+    // playback CPU even when hardware decoding is active. Prefer the GL renderer,
+    // unless a renderer was already chosen — data/stremio.sh sets `opengl` for
+    // Nvidia, and `opengl` and `gl` are the same renderer here, so the two compose.
+    // Must be set before GTK initializes.
+    //
+    // The name is `gl`: GTK renamed the new GL renderer in 4.18. `ngl` still
+    // resolves to it as a deprecated alias, but warns. Any name GTK does not
+    // recognize falls back to the Vulkan renderer this is meant to avoid, so the
+    // value is worth keeping in step with `GSK_RENDERER=help`.
+    //
+    // SAFETY: this runs at the very start of main, before any other threads are
+    // spawned, so there is no concurrent access to the environment.
+    if env::var_os("GSK_RENDERER").is_none() {
+        unsafe { env::set_var("GSK_RENDERER", "gl") };
+    }
+
     tracing_subscriber::fmt::init();
 
     let data_dir = dirs::data_dir()


### PR DESCRIPTION
Split out of #108. This one depends on #108 and should be merged after it, since it folds the two hwdec call sites that PR introduces into a single helper. The diff shown here therefore includes the #108 commits until that one lands.

On the proprietary NVIDIA driver `auto-safe` only offers copy back, which resolves to `vulkan-copy`. On 4K HDR that copies every p010 frame, roughly 25 MB each, through system RAM and pins about 100% of a core. Requesting `nvdec` explicitly gets CUDA interop zero copy instead and frames stay on the GPU. Mesa is unchanged and keeps `auto-safe`, which already selects VAAPI dmabuf zero copy.

Measured on a GTX 1060 Pascal, driver 580, KWin Wayland at 170% scale, in the flatpak, 4K HDR, CPU of the `stremio` process during steady fullscreen playback:

| decode mode | CPU |
| --- | --: |
| auto-copy, resolving to vulkan-copy | ~100% |
| nvdec | ~23% |

Clean image, no artifacts. The remaining 23% is the 4K HDR render and present path, mpv plus GSK plus tone mapping, which matches what Mesa costs for the same content.

The change is one `default_hwdec()` helper used by both the mpv initializer and the web UI remap, plus a `STREMIO_HWDEC` override so decode modes can be compared without a rebuild:

```
flatpak run --env=STREMIO_HWDEC=auto-copy com.stremio.Stremio.Devel
```

## Packaging requirement

`nvdec` zero copy needs libmpv and ffmpeg built with CUDA interop, mpv `--enable-cuda-hwaccel --enable-cuda-interop` and ffmpeg `--enable-ffnvcodec`. Verified with libmpv 0.41 and ffmpeg 7.1 from the GNOME 50 runtime, and with system libmpv on Ubuntu 24.04, 26.04 and 26.10, which all ship it. Where the interop is missing, mpv falls back to software decoding rather than silently to copy back, so the failure mode is visible in the log.

## On whether nvdec works under vo=libmpv

This came up in review on #108. The manual says `nvdec` requires `--vo=gpu` or `--vo=gpu-next`, but the same table says the same thing about `vaapi`, and zero copy VAAPI demonstrably works in this shell. The libmpv render backend is the same gpu pipeline: `video/out/gpu/libmpv_gpu.c` calls `gl_video_init_hwdecs` with `load_all_by_default` set to true, where `video/out/vo_gpu.c` passes false, so libmpv loads every hwdec interop eagerly rather than on demand. The manual says as much under `--gpu-hwdec-interop`, which is documented as useful for "the gpu and libmpv VOs". At startup the flatpak logs it:

```
[libmpv_render] Loading hwdec driver 'vaapi'
[libmpv_render] Loading hwdec driver 'cuda'
[libmpv_render] Loading hwdec driver 'vulkan'
```

mpv also never silently substitutes the copy variant. `nvdec` and `nvdec-copy` are separate entries and `vd_lavc.c` skips non copying entries only when `auto-copy` was requested, so an explicit `nvdec` either gets the interop or falls back to software. Details and the equivalent Mesa evidence are in my comment on #108.
